### PR TITLE
`MonadFix` can only be lifted through `MonadTransControlIdentity`.

### DIFF
--- a/src/Control/Monad/Trans/Elevator.hs
+++ b/src/Control/Monad/Trans/Elevator.hs
@@ -61,9 +61,8 @@ instance (Monad (t m), MonadTransControl t, Monad m, Alternative m) => Alternati
 instance (Monad (t m), MonadTrans t, MonadFail m) => MonadFail (Elevator t m) where
   fail = lift . fail
 
-instance (Monad (t m), MonadTransControl t, MonadFix m) => MonadFix (Elevator t m) where
-  mfix f = (restoreT . pure =<<) $ liftWith $ \ runT ->
-    mfix $ \ x -> runT $ (f =<<) $ restoreT $ pure x
+instance (Monad (t m), MonadTransControlIdentity t, MonadFix m) => MonadFix (Elevator t m) where
+  mfix f = liftWithIdentity $ \ runT -> mfix $ \ x -> runT $ f x
 
 instance (Monad (t m), MonadTrans t, MonadIO m) => MonadIO (Elevator t m) where
   liftIO = lift . liftIO


### PR DESCRIPTION
The type checker also accepted the old version, but unfortunately,
whenever there was monadic state involved, the program would hang.

I am not 100% sure, whether this really is impossible to just handle it
with laziness annotations.

But then again for `ExceptT`, there would have to be an additional case
handling `Left`.

But I can safely say, the previous implementation here hung for
`StateT` and `ExceptT`, when the implementations from "containers" still
worked.